### PR TITLE
Fix invalid terraform template

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,7 +39,7 @@ resource "google_compute_instance" "microkube" {
 
   tags = ["allow-webhook"]
 
-  metadata {
+  metadata = {
     sshKeys = "${var.ssh_user}:${file("${var.ssh_public_key}")}"
   }
 
@@ -53,6 +53,7 @@ resource "google_compute_instance" "microkube" {
     ]
 
     connection {
+      host        = "${google_compute_instance.microkube.network_interface.0.access_config.0.nat_ip}"
       type        = "ssh"
       user        = "${var.ssh_user}"
       private_key = "${file("${var.ssh_private_key}")}"
@@ -64,6 +65,7 @@ resource "google_compute_instance" "microkube" {
     destination = "/home/${var.ssh_user}/microkube"
 
     connection {
+      host        = "${google_compute_instance.microkube.network_interface.0.access_config.0.nat_ip}"
       type        = "ssh"
       user        = "${var.ssh_user}"
       private_key = "${file("${var.ssh_private_key}")}"
@@ -74,6 +76,7 @@ resource "google_compute_instance" "microkube" {
     script = "../bin/install.sh"
 
     connection {
+      host        = "${google_compute_instance.microkube.network_interface.0.access_config.0.nat_ip}"
       type        = "ssh"
       user        = "${var.ssh_user}"
       private_key = "${file("${var.ssh_private_key}")}"
@@ -84,6 +87,7 @@ resource "google_compute_instance" "microkube" {
     script = "../bin/start.sh"
 
     connection {
+      host        = "${google_compute_instance.microkube.network_interface.0.access_config.0.nat_ip}"
       type        = "ssh"
       user        = "${var.ssh_user}"
       private_key = "${file("${var.ssh_private_key}")}"


### PR DESCRIPTION
Fixed some template file errors.

before:
```sh
$ terraform validate

Error: Unsupported block type

  on main.tf line 42, in resource "google_compute_instance" "microkube":
  42:   metadata {

Blocks of type "metadata" are not expected here. Did you mean to define
argument "metadata"? If so, use the equals sign to assign it a value.

Error: Missing required argument

  on main.tf line 55, in resource "google_compute_instance" "microkube":
  55:     connection {

The argument "host" is required, but no definition was found.
```

after:
```sh
$ terraform validate
Success! The configuration is valid.
```