### PR TITLE
Enhancement: Use appropriate words

### DIFF
--- a/config/barong/authz_rules.yml
+++ b/config/barong/authz_rules.yml
@@ -1,6 +1,6 @@
 #
-# pass for whitelisted (public) routes
-# block for blacklisted routes
+# pass for allowlisted (public) routes
+# block for denylisted routes
 #
 rules:
   pass:

--- a/config/barong/seeds.yml
+++ b/config/barong/seeds.yml
@@ -29,12 +29,12 @@ levels:
     description: "User personal documents have been verified"
 
 restrictions: {}
-# - { category: whitelist, scope: country, value: UA, state: disabled }
+# - { category: allowlist, scope: country, value: UA, state: disabled }
 # - { category: maintenance, scope: all, value: all, state: disabled }
-# - { category: blacklist, scope: ip, value: 164.116.47.255, state: disabled, code: 433 }
-# - { category: blacklist, scope: ip_subnet, value: 164.116.47.0/24, state: disabled, code: 434 }
-# - { category: blacklist, scope: country, value: USA, state: disabled, code: 435 }
-# - { category: blacklist, scope: continent, value: SA, state: disabled, code: 436 }
+# - { category: denylist, scope: ip, value: 164.116.47.255, state: disabled, code: 433 }
+# - { category: denylist, scope: ip_subnet, value: 164.116.47.0/24, state: disabled, code: 434 }
+# - { category: denylist, scope: country, value: USA, state: disabled, code: 435 }
+# - { category: denylist, scope: continent, value: SA, state: disabled, code: 436 }
 
 permissions:
 # SUPER ADMIN has an access to the whole system without any limits

--- a/templates/config/barong/seeds.yml.erb
+++ b/templates/config/barong/seeds.yml.erb
@@ -29,12 +29,12 @@ levels:
     description: "User personal documents have been verified"
 
 restrictions: {}
-# - { category: whitelist, scope: country, value: UA, state: disabled }
+# - { category: allowlist, scope: country, value: UA, state: disabled }
 # - { category: maintenance, scope: all, value: all, state: disabled }
-# - { category: blacklist, scope: ip, value: 164.116.47.255, state: disabled, code: 433 }
-# - { category: blacklist, scope: ip_subnet, value: 164.116.47.0/24, state: disabled, code: 434 }
-# - { category: blacklist, scope: country, value: USA, state: disabled, code: 435 }
-# - { category: blacklist, scope: continent, value: SA, state: disabled, code: 436 }
+# - { category: denylist, scope: ip, value: 164.116.47.255, state: disabled, code: 433 }
+# - { category: denylist, scope: ip_subnet, value: 164.116.47.0/24, state: disabled, code: 434 }
+# - { category: denylist, scope: country, value: USA, state: disabled, code: 435 }
+# - { category: denylist, scope: continent, value: SA, state: disabled, code: 436 }
 
 permissions:
 # SUPER ADMIN has an access to the whole system without any limits


### PR DESCRIPTION
The technology industry has started to replace problematic racist terminology with more appropriate and precise. It's time to shift from naming conventions, which cause misunderstanding.

### [Google](https://developers.google.com/style/word-list)
> Avoid blacklist and whitelist. Instead, use more precise terms that are appropriate to your domain, such as denylist/allowlist or blocklist/allowlist.
### [IBM](https://cloud.ibm.com/docs/overview?topic=overview-glossary)
> allowlist
> A list of items, such as usernames, email addresses, or IP addresses, that are granted access to a certain system or function. When an allowlist is used for access control, all entities are denied access, except for those that are included in the allowlist. See also blocklist.
> blocklist
> A list of items, such as usernames, email addresses, or IP addresses, that are denied access to a certain system or function. When a blocklist is used for access control, all entities are allowed access, except for those that are included in the blocklist. See also allowlist.