### PR TITLE
Remove [test] from litecoind config

### DIFF
--- a/templates/config/litecoin.conf.erb
+++ b/templates/config/litecoin.conf.erb
@@ -10,7 +10,6 @@ onlynet=ipv4
 
 <%- unless litecoind['network'] == 'mainnet' -%>
 <%= "#{litecoind['network']}=1" %>
-[test]
 <%- end -%>
 rpcuser=<%= litecoind['rpcuser'] %>
 rpcpassword=<%= litecoind['rpcpassword'] %>


### PR DESCRIPTION
fix #224: litecoind doesn't seem to like [test] in litecoin.conf