### PR TITLE
Add auth0 config to barong

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -35,6 +35,10 @@ vault:
   peatio_matching_token: changeme
   barong_token: changeme
   finex_engine_token: changeme
+auth0:
+  enabled: false
+  domain: changeme
+  client_id: changeme
 database:
   host: db
   adapter: mysql

--- a/templates/config/barong.env.erb
+++ b/templates/config/barong.env.erb
@@ -8,6 +8,11 @@ RAILS_ENV=production
 
 SECRET_KEY_BASE=64
 
+<%- if @config['auth0']['enabled'] -%>
+AUTH0_DOMAIN=<%= @config['auth0']['domain'] %>
+AUTH0_CLIENT_ID=<%= @config['auth0']['client_id'] %>
+<%- end -%>
+
 <%- if @config['database']['adapter'] == 'postgresql' %>
 DATABASE_COLLATION=""
 DATABASE_ADAPTER="postgresql"


### PR DESCRIPTION
Barong has the ability to specify the auth0 configuration now.
https://www.openware.com/sdk/2.6/docs/barong/configuration.html#auth0-configuration
Here is PR with template and config variables for this